### PR TITLE
update comment for retry code to send buffered logs

### DIFF
--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -218,7 +218,7 @@ common.loggly = function () {
   }
 
   //
-  // retries to send buffered logs to loggly in every 5 sec
+  // retries to send buffered logs to loggly in every 30 seconds
   //
   if (timerFunctionForBufferedLogs === null) {
     timerFunctionForBufferedLogs = setInterval(function () {


### PR DESCRIPTION
I had set 30 seconds timer to retry sending buffered logs to Loggly in node library but the commented line was not updated.  I have corrected it in this PR.  Kindly review and merge it.