### PR TITLE
Fix undefined issue while logging from node-loggly-bulk library 

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -105,6 +105,15 @@ util.inherits(Loggly, events.EventEmitter);
 //  - http://www.loggly.com/docs/api-sending-data/
 //
 Loggly.prototype.log = function (msg, tags, callback) {
+
+  //
+  // typeof msg is string when we are sending logs using node-loggly-bulk.
+  // If we are sending logs using winston-loggly-bulk, msg is an object.
+  //
+  if (typeof(msg) === 'string') {
+    msg = { message: msg };
+  }
+
   msg.message = truncateLargeMessage(msg.message)
   if (!callback && typeof tags === 'function') {
     callback = tags;

--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -113,8 +113,9 @@ Loggly.prototype.log = function (msg, tags, callback) {
   if (typeof(msg) === 'string') {
     msg = { message: msg };
   }
-
-  msg.message = truncateLargeMessage(msg.message)
+  if(msg.message) {
+    msg.message = truncateLargeMessage(msg.message);
+  }    
   if (!callback && typeof tags === 'function') {
     callback = tags;
     tags = null;

--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -28,14 +28,20 @@ function stringify(msg) {
 //
 // function to truncate message over 1 MB
 // 
-function truncateLargeMessage(message) {  
+function truncateLargeMessage(message) {
   var maximumBytesAllowedToLoggly = EVENT_SIZE;
-  var bytesLengthOfLogMessage = Buffer.byteLength(message); 
+  var bytesLengthOfLogMessage = Buffer.byteLength(message);
+  var isMessageTruncated = false;
   if(bytesLengthOfLogMessage > maximumBytesAllowedToLoggly) {
     message = message.slice(0, maximumBytesAllowedToLoggly);
+    isMessageTruncated = true;
   }
-  return message;
+  return {
+    message: message,
+    isMessageTruncated: isMessageTruncated
+  };
 }
+
 //
 // function createClient (options)
 //   Creates a new instance of a Loggly client.
@@ -105,17 +111,18 @@ util.inherits(Loggly, events.EventEmitter);
 //  - http://www.loggly.com/docs/api-sending-data/
 //
 Loggly.prototype.log = function (msg, tags, callback) {
-
-  //
-  // typeof msg is string when we are sending logs using node-loggly-bulk.
-  // If we are sending logs using winston-loggly-bulk, msg is an object.
-  //
-  if (typeof(msg) === 'string') {
-    msg = { message: msg };
+  // typeof msg is string when we are using node-loggly-bulk to send logs.
+  // If we are sending logs using winston-loggly-bulk, msg is object.
+  // Check if 'msg' is an object, if yes then stringify it to truncate it over 1MB.
+  var truncatedMessageObject = null;
+  if(typeof(msg) === 'object'){
+    var stringifiedMessage = JSON.stringify(msg)
+    truncatedMessageObject = truncateLargeMessage(stringifiedMessage);
+    msg = truncatedMessageObject.isMessageTruncated ? truncatedMessageObject.message : msg;
+  }else if (typeof(msg) === 'string') {
+    truncatedMessageObject = truncateLargeMessage(msg);
+    msg = truncatedMessageObject.isMessageTruncated ? truncatedMessageObject.message : msg;
   }
-  if(msg.message) {
-    msg.message = truncateLargeMessage(msg.message);
-  }    
   if (!callback && typeof tags === 'function') {
     callback = tags;
     tags = null;


### PR DESCRIPTION
I debugged code with `node-loggly-bulk` library and found that type of `msg` is a string which should be an object(`winston-loggly-bulk` library is sending log data to `node-loggly-bulk` in object form). That's why the value of `msg.message` object was `undefined`.

From node version 7.0.0, node will throw an error when we will pass invalid input to Buffer.byteLength.

Ref: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V7.md#7.0.0
Merged PR: https://github.com/nodejs/node/pull/8946

In this PR I have put a condition to check if the `msg` is a string (If we are logging using `node-loggly-bulk`) and then converting to an object. So both library will work correctly. 

It will fix the issue #10.