### PR TITLE
upgrade version of node-loggly-bulk in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-loggly-bulk",
   "description": "A client implementation for Loggly cloud Logging-as-a-Service API",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@mchaudhary @mostlyjason The version of **node-loggly-bulk** is **1.1.0** in **package.json** file which should be same as per latest **npm** version. Please follow the below link:

https://www.npmjs.com/package/node-loggly-bulk

As I have resolved some bugs and issue in this library, I need to publish a new npm package for updated library code. I noticed that **Winston** is on version 2 i.e. latest **Winston** version is **2.3.1** so we should also move to version 2 for both **node-loggly-bulk** and **winston-loggly-bulk**. In this way, all **Winston**, **winston-loggly-bulk** and **node-loggly-bulk** will be in sync.

In that reference, here, I have updated the package.json file for version **2.0.0**. Please review the change and kindly merge the PR. 