### PR TITLE
decrease waiting time to send bulk logs

### DIFF
--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -206,7 +206,7 @@ common.loggly = function () {
     if (timerFunction === null) {
       timerFunction = setInterval(function () {
         sendBulkLogs();
-      },30000);
+      },5000);
     }
     arrMsg.push(requestBody);
     if (arrMsg.length === arrSize) {


### PR DESCRIPTION
@mchaudhary, @mostlyjason, This PR is to decrease the waiting time to send bulk logs. Before library waits for 30 seconds to collect logs and then sends them to Loggly but now library will send Logs in each 5 seconds. 
