### PR TITLE
Clear timerFunctionForBufferedLogs if not needed

### DIFF
--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -222,8 +222,11 @@ common.loggly = function () {
   //
   if (timerFunctionForBufferedLogs === null) {
     timerFunctionForBufferedLogs = setInterval(function () {
-      if (arrBufferedMsg.length) sendBufferdLogstoLoggly();
+      if (arrBufferedMsg.length) { sendBufferdLogstoLoggly(); }
     }, bufferOptions.retriesInMilliSeconds);
+  } else if (timerFunctionForBufferedLogs && !arrBufferedMsg.length) {
+    clearInterval(timerFunctionForBufferedLogs);
+    timerFunctionForBufferedLogs = null;
   }
 
 


### PR DESCRIPTION
This is an example of a fix for https://github.com/loggly/winston-loggly-bulk/issues/12 with a small amount of code change.


Please note that these lines in `common.js`:


https://github.com/loggly/node-loggly-bulk/blob/ea918224b6a88123cb73dda0227cb25a207c2170/lib/loggly/common.js#L205-L210


produce the same bug when `isBulk` is `true`. 

See https://github.com/loggly/winston-loggly-bulk/issues/13. This PR does *not* address that just in case you would like to implement a better timing solution than using `setInterval`. I would consider this fix temporary if merged. 

Thanks!