### PR TITLE
Clear all open interval and resolve callback error

### DIFF
--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -206,8 +206,11 @@ common.loggly = function () {
     if (timerFunction === null) {
       timerFunction = setInterval(function () {
         sendBulkLogs();
-      },30000);
-    }
+      },5000);
+    } else if (timerFunction && !arrMsg.length) {
+        clearInterval(timerFunction);
+        timerFunction = null;
+      }
     arrMsg.push(requestBody);
     if (arrMsg.length === arrSize) {
       sendBulkLogs();
@@ -224,7 +227,10 @@ common.loggly = function () {
     timerFunctionForBufferedLogs = setInterval(function () {
       if (arrBufferedMsg.length) sendBufferdLogstoLoggly();
     }, bufferOptions.retriesInMilliSeconds);
-  }
+  } else if (timerFunctionForBufferedLogs && !arrBufferedMsg.length) {
+     clearInterval(timerFunctionForBufferedLogs);
+     timerFunctionForBufferedLogs = null;
+    }
 
 
   function sendBufferdLogstoLoggly() {


### PR DESCRIPTION
@mchaudhary @mostlyjason, I looked at the PR #14 and used the clearInterval() in our library to clear open interval for **sendBufferdLogstoLoggly()** function but using clearInterval() function only for buffer function did not help to overcome the callback issue. I used the clearInterval() function for both **sendBulkLogs()** and **sendBufferdLogstoLoggly()** functions then the callback error was removed. I ran the application continue for 30 minutes but the error did not occur. Before it was occurring in less than a minute. 
 
I tested in below scenarios:

In both Bulk and Input mode with below conditions-

(a) Sending a single event (Worked Fine)
(b) Sending events in a loop (Worked Fine)
(c) Sending events continuous in a loop at a specific interval (Worked Fine)

In Network Outage case. (Worked Fine)

This PR will resolve the issue https://github.com/loggly/winston-loggly-bulk/issues/13

Please review.