### PR TITLE
clear all open intervals if not needed

### DIFF
--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -206,11 +206,12 @@ common.loggly = function () {
     if (timerFunction === null) {
       timerFunction = setInterval(function () {
         sendBulkLogs();
+        if (timerFunction && !arrMsg.length) {
+          clearInterval(timerFunction)
+          timerFunction = null;
+        }
       },5000);
-    } else if (timerFunction && !arrMsg.length) {
-        clearInterval(timerFunction);
-        timerFunction = null;
-      }
+    }
     arrMsg.push(requestBody);
     if (arrMsg.length === arrSize) {
       sendBulkLogs();
@@ -226,11 +227,12 @@ common.loggly = function () {
   if (timerFunctionForBufferedLogs === null) {
     timerFunctionForBufferedLogs = setInterval(function () {
       if (arrBufferedMsg.length) sendBufferdLogstoLoggly();
+        if (timerFunctionForBufferedLogs && !arrBufferedMsg.length) {
+          clearInterval(timerFunctionForBufferedLogs);
+          timerFunctionForBufferedLogs = null;
+        }
     }, bufferOptions.retriesInMilliSeconds);
-  } else if (timerFunctionForBufferedLogs && !arrBufferedMsg.length) {
-     clearInterval(timerFunctionForBufferedLogs);
-     timerFunctionForBufferedLogs = null;
-    }
+  }
 
 
   function sendBufferdLogstoLoggly() {


### PR DESCRIPTION
@mchaudhary @mostlyjason In this PR, I have used **clearIntervals()** function to clear all open intervals. I have tested the library code and observed that clearInterval will clear the open intervals each time after sending logs but if continue logging is taking place then it is required to keep the interval open otherwise **sendBulkLogs()** and **sendBufferdLogstoLoggly()** functions will not call and logging will not happen.

So in that way, even after implementing clearInterval function if we check for open handlers using **wtf-node** package in our library then it may possible that those existing open handlers will be there to keep the logging continue. 

Related to https://github.com/loggly/winston-loggly-bulk/issues/12

Please review. 