### PR TITLE
Handling syntax error while parsing HTML response

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -185,10 +185,12 @@ Loggly.prototype.log = function (msg, tags, callback) {
 
   common.loggly(logOptions, callback, function (res, body) {
     try {
-      var result = JSON.parse(body);
-      self.emit('log', result);
-      if (callback) {
-        callback(null, result);
+      if(body && res.statusCode.toString() === '200'){
+        var result = JSON.parse(body);
+        self.emit('log', result);
+        if (callback) {
+          callback(null, result);
+        }
       }
     }
     catch (ex) {

--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -192,6 +192,8 @@ Loggly.prototype.log = function (msg, tags, callback) {
           callback(null, result);
         }
       }
+      else
+       console.log('Error Code- ' + res.statusCode + ' "' + res.statusMessage + '"');
     }
     catch (ex) {
       if (callback) {


### PR DESCRIPTION
@mchaudhary @mostlyjason, This PR is to resolve the issue https://github.com/loggly/node-loggly-bulk/issues/17. 

In this PR, I have put an if condition to check if the body contains some data and not undefined and also parse the body when the response code is **200 OK**. When there is some error returned from the server in HTML form in the body and when it goes to parse, it throws a syntax error. So I am checking both the **body** and the response code to parse the body further. 

Please review. 