### PR TITLE
Allow bulk messages to be passed as an array

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -144,7 +144,7 @@ Loggly.prototype.log = function (msg, tags, callback) {
     }
   }
 
-  msg = serialize(msg);
+  msg = this.isBulk && Array.isArray(msg) ? msg.map(serialize) : serialize(msg);
 
   logOptions = {
     uri:     this.isBulk ? this.urls.bulk : this.urls.log,

--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -212,7 +212,13 @@ common.loggly = function () {
         }
       },5000);
     }
-    arrMsg.push(requestBody);
+
+    if (Array.isArray(requestBody)) {
+      arrMsg.push.apply(arrMsg, requestBody);
+    } else {
+      arrMsg.push(requestBody);
+    }
+
     if (arrMsg.length === arrSize) {
       sendBulkLogs();
     }


### PR DESCRIPTION
This PR allows for the previous bulk logging functionality from [winstonjs/node-loggly](https://github.com/winstonjs/node-loggly) which is relied on by [bunyan-loggly](https://github.com/MauriceButler/bunyan-loggly).

The PR will allow `bunyan-loggly` to switch from `winstonjs/node-loggly` to `node-loggly-bulk` as per https://github.com/MauriceButler/bunyan-loggly/issues/13

