### PR TITLE
Replace timespan with Moment and remove security warnings

### DIFF
--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -224,7 +224,7 @@ common.loggly = function () {
   //
   // retries to send buffered logs to loggly in every 30 seconds
   //
-  if (timerFunctionForBufferedLogs === null) {
+  if (timerFunctionForBufferedLogs === null && bufferOptions) {
     timerFunctionForBufferedLogs = setInterval(function () {
       if (arrBufferedMsg.length) sendBufferdLogstoLoggly();
         if (timerFunctionForBufferedLogs && !arrBufferedMsg.length) {
@@ -258,7 +258,7 @@ common.loggly = function () {
 // This function will store logs into buffer
 //
   function storeLogs(logs) {
-    if (!logs.length) return;
+    if (!logs.length || !bufferOptions) return;
     var numberOfLogsToBeRemoved = (arrBufferedMsg.length + logs.length) - bufferOptions.size;
     if (numberOfLogsToBeRemoved > 0) arrBufferedMsg = arrBufferedMsg.splice(numberOfLogsToBeRemoved);
       arrBufferedMsg = arrBufferedMsg.concat(logs);

--- a/lib/loggly/search.js
+++ b/lib/loggly/search.js
@@ -9,7 +9,7 @@
 var events = require('events'),
     util = require('util'),
     qs = require('querystring'),
-    timespan = require('timespan'),
+    moment = require('moment'),
     common = require('./common');
 
 //
@@ -139,18 +139,18 @@ Search.prototype._checkRange = function () {
   this.options.until = this.options.until || 'now';
   this.options.from  = this.options.from  || '-24h';
 
-  if (!timespan.parseDate(this.options.until)) {
+  if (!moment.parseDate(this.options.until)) {
     this.options.until = 'now';
   }
 
-  if (!timespan.parseDate(this.options.from)) {
+  if (!moment.parseDate(this.options.from)) {
     this.options.from = '-24h';
   }
 
-  if (timespan.fromDates(this.options.from, this.options.until) < 0
+  if (moment.fromDates(this.options.from, this.options.until) < 0
     || this.options.until === this.options.from) {
     //
-    // If the length of the timespan for this Search instance is
+    // If the length of the moment for this Search instance is
     // negative then set it to default values
     //
     this.options.until = 'now';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-loggly-bulk",
   "description": "A client implementation for Loggly cloud Logging-as-a-Service API",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "request": ">=2.76.0 <3.0.0",
-    "timespan": "2.3.x",
+    "moment": "^2.18.1",
     "json-stringify-safe": "5.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
@mchaudhary @mostlyjason, In this pull request, I have removed the **timespan** dependency which was causing the security vulnerability issues in node applications. The **Node Security Platform** shows these warnings in a node project. 

This PR will fix the issue https://github.com/loggly/node-loggly-bulk/issues/20. Please review.