### PR TITLE
Resolve TypeError for bunyan-loggly

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -158,7 +158,7 @@ Loggly.prototype.log = function (msg, tags, callback) {
       accept:           '*/*',
       'user-agent':     this.userAgent,
       'content-type':   this.json ? 'application/json' : 'text/plain',
-      'content-length': Buffer.byteLength(msg)
+      'content-length': Buffer.byteLength(JSON.stringify(msg))
     }
   };
 


### PR DESCRIPTION
@mchaudhary @mostlyjason The issue https://github.com/loggly/node-loggly-bulk/issues/10 is related to bunyan-loggly library in which when we log any message then it comes in the array form and when it goes to calculate the byte length, it breaks. But in our **node-loggly-bulk** library when we log the data it comes in the string form and then we calculate the byte length of the log message using **Buffer.byteLength()** method without any error so it is not breaking with our library.

In this PR, I used the **JSON.stringify()** method to calculate the byte length of the log message after converting it into a JSON string. This does not change anything in the log and passes in all scenarios like if we pass a JSON object or a string or if the log comes in the array form. 

I have checked this with **bunyan-loggly, node-loggly-bulk and winston-loggly-bulk** libraries and everything looked fine to me.