### PR TITLE
Remove content length and resolve type-error issue

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -157,8 +157,7 @@ Loggly.prototype.log = function (msg, tags, callback) {
       host:             this.host,
       accept:           '*/*',
       'user-agent':     this.userAgent,
-      'content-type':   this.json ? 'application/json' : 'text/plain',
-      'content-length': Buffer.byteLength(JSON.stringify(msg))
+      'content-type':   this.json ? 'application/json' : 'text/plain'
     }
   };
 


### PR DESCRIPTION
@mchaudhary @mostlyjason In this PR, I have removed the content-length from the request header and now the type error issue https://github.com/loggly/node-loggly-bulk/issues/10 will no longer exist.

**Note:** The testing is in progress, I will update the npm once I am done with it. 