### PR TITLE
Add new flag for network errors

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -77,6 +77,7 @@ var Loggly = exports.Loggly = function (options) {
   this.useTagHeader = 'useTagHeader' in options ? options.useTagHeader : true;
   this.isBulk       = options.isBulk || false;
   this.bufferOptions = options.bufferOptions || {size: 500, retriesInMilliSeconds: 30 * 1000};
+  this.networkErrorsOnConsole = options.networkErrorsOnConsole || false;
   //
   // Set the tags on this instance.
   //
@@ -153,6 +154,7 @@ Loggly.prototype.log = function (msg, tags, callback) {
     proxy:   this.proxy,
     isBulk: this.isBulk,
     bufferOptions: this.bufferOptions,
+    networkErrorsOnConsole: this.networkErrorsOnConsole,
     headers: {
       host:             this.host,
       accept:           '*/*',

--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -90,7 +90,8 @@ common.loggly = function () {
       proxy,
       isBulk,
       uri,
-      bufferOptions;
+      bufferOptions,
+      networkErrorsOnConsole;
 
   //
   // Now that we've popped off the two callbacks
@@ -113,6 +114,7 @@ common.loggly = function () {
       headers     = args[0].headers;
       proxy       = args[0].proxy;
       bufferOptions = args[0].bufferOptions;
+      networkErrorsOnConsole = args[0].networkErrorsOnConsole;
     }
   }
   else if (args.length === 2) {
@@ -201,7 +203,7 @@ common.loggly = function () {
               return onError((new Error('Loggly Error (' + responseCode + '): ' + httpStatusCode.badToken.message)));
             }
             if (responseCode === httpStatusCode.success.code && input.attemptNumber >= eventRetried) {
-              console.log('log #' + input.id + ' sent successfully after ' + input.attemptNumber + ' retries');
+              if (networkErrorsOnConsole) console.log('log #' + input.id + ' sent successfully after ' + input.attemptNumber + ' retries');
             }
             if (responseCode === httpStatusCode.success.code) {
               success(res, body);
@@ -239,7 +241,7 @@ common.loggly = function () {
               return onError((new Error('Loggly Error (' + responseCode + '): ' + httpStatusCode.badToken.message)));
             }
             if (responseCode === httpStatusCode.success.code && bulk.attemptNumber >= eventRetried) {
-              console.log('log #' + bulk.id + ' sent successfully after ' + bulk.attemptNumber + ' retries');
+              if (networkErrorsOnConsole) console.log('log #' + bulk.id + ' sent successfully after ' + bulk.attemptNumber + ' retries');
             }
             if (responseCode === httpStatusCode.success.code) {
               success(res, body);
@@ -285,22 +287,22 @@ common.loggly = function () {
   //
   function retryOnError(mode, response) {
     function tryAgainIn(sleepTimeMs) {
-      console.log('log #' + mode.id + ' - Trying again in ' + sleepTimeMs + '[ms], attempt no. ' + mode.attemptNumber);
+      if (networkErrorsOnConsole) console.log('log #' + mode.id + ' - Trying again in ' + sleepTimeMs + '[ms], attempt no. ' + mode.attemptNumber);
       setTimeout(function () {
         isBulk ? sendBulkLogs(mode) : sendInputLogs(mode);
       }, sleepTimeMs);
     }
     if (mode.attemptNumber >= numberOfRetries) {
       if (response.code) {
-        console.error('Failed log #' + mode.id + ' after ' + mode.attemptNumber + ' retries on error = ' + response, response);
+        if (networkErrorsOnConsole) console.error('Failed log #' + mode.id + ' after ' + mode.attemptNumber + ' retries on error = ' + response, response);
       } else {
-        console.error('Failed log #' + mode.id + ' after ' + mode.attemptNumber + ' retries on error = ' + response.statusCode + ' ' + response.statusMessage);
+        if (networkErrorsOnConsole) console.error('Failed log #' + mode.id + ' after ' + mode.attemptNumber + ' retries on error = ' + response.statusCode + ' ' + response.statusMessage);
       }
     } else {
         if (response.code) {
-          console.log('log #' + mode.id + ' - failed on error: ' + response);
+          if (networkErrorsOnConsole) console.log('log #' + mode.id + ' - failed on error: ' + response);
         } else {  
-          console.log('log #' + mode.id + ' - failed on error: ' + response.statusCode + ' ' + response.statusMessage);
+          if (networkErrorsOnConsole) console.log('log #' + mode.id + ' - failed on error: ' + response.statusCode + ' ' + response.statusMessage);
         }
         sleepTimeMs = mode.sleepUntilNextRetry;
         mode.sleepUntilNextRetry = mode.sleepUntilNextRetry * 2;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-loggly-bulk",
   "description": "A client implementation for Loggly cloud Logging-as-a-Service API",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As per the current scenario, the library writes the networks errors on console which sometimes pollute the other important logs when the numbers are so high.

In this PR, I have made the error writing to `false` by default and added the new flag variable whose value can be set from the main application file. This variable basically allow the user to set the default value to true which will starts printing the errors on console. So if any user wants those error logs then he can set the value to `true` easily. 

**Note:** This PR is also related to https://github.com/loggly/winston-loggly-bulk/pull/41 so merging both is required to work this feature. 