### PR TITLE
Handle undefined tags

### DIFF
--- a/lib/loggly/client.js
+++ b/lib/loggly/client.js
@@ -172,9 +172,12 @@ Loggly.prototype.log = function (msg, tags, callback) {
     : this.tags;
 
   //
-  // Optionally send `X-LOGGLY-TAG` if we have them
+  // Optionally send `X-LOGGLY-TAG` if we have them.
+  // Set the 'X-LOGGLY-TAG' only when we have actually some tag value.
+  // The library receives "400 Bad Request" in response when the
+  // value of 'X-LOGGLY-TAG' is empty string in request header.
   //
-  if (tags) {
+  if (tags && tags.length) {
     // Decide whether to add tags as http headers or add them to the URI.
     if (this.useTagHeader) {
       logOptions.headers['X-LOGGLY-TAG'] = tags.join(',');
@@ -227,7 +230,7 @@ Loggly.prototype.tagFilter = function (tags) {
     //
     // Remark: length may need to use Buffer.byteLength?
     //
-    return isSolid.test(tag) && tag.length <= 64;
+    return tag && isSolid.test(tag) && tag.length <= 64;
   });
 };
 

--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -147,7 +147,7 @@ common.loggly = function () {
     }
   }
   var requestOptions = {
-    uri: isBulk ? uri + '/tag/' + headers['X-LOGGLY-TAG'] : uri,
+    uri: (isBulk && headers['X-LOGGLY-TAG']) ? uri + '/tag/' + headers['X-LOGGLY-TAG'] : uri,
     method: method,
     headers: isBulk ? {} : headers || {},             // Set headers empty for bulk
     proxy: proxy


### PR DESCRIPTION
In this PR, I have handled the **undefined tag** issue https://github.com/loggly/winston-loggly-bulk/issues/33 which crashes the whole app.

I've covered the below points in this bug fix-

(a) Calculate the tag length only when there is actually any tag defined. Ref- [#233](https://github.com/loggly/node-loggly-bulk/pull/40/files#diff-7cdb566a2625a8b0ac4562928ffcaf92R233)
(b) Set the X-LOGGLY-TAG property into the request header only when there is actually a tag length into the tag array. Ref- [#180](https://github.com/loggly/node-loggly-bulk/pull/40/files#diff-7cdb566a2625a8b0ac4562928ffcaf92R180)
(c) In Bulk mode, the X-LOGGLY-TAG property sets again to make the Loggly URL so modified the code to use this propertry only when the headers 'X-LOGGLY-TAG' contains some value. Ref - [#150](https://github.com/loggly/node-loggly-bulk/pull/40/files#diff-f0796bac0feab3f0c1894b8a119ef018R150)

I have tested it initially and found working now. But complete testing is still in-progress. 

**UPDATE:** It has been tested successfully so it's ready to merge. 

Thanks!