### PR TITLE
Ensure `request` >= 2.83.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "loggly"
   ],
   "dependencies": {
-    "request": ">=2.76.0 <3.0.0",
+    "request": ">=2.83.0 <3.0.0",
     "moment": "^2.18.1",
     "json-stringify-safe": "5.0.x"
   },


### PR DESCRIPTION
Versions of `request` before 2.83.0 are susceptible to a ReDoS attack via it's dependency `tough-cookie`. Version 2.83.0 of `request` upgrades the version of `touch-cookie` to one that is no longer susceptible to the attack.

Vulnerability advisory:
https://www.npmjs.com/advisories/525

`request` CHANGELOG:
https://github.com/request/request/blob/master/CHANGELOG.md#v2830-20170927