### PR TITLE
CVE-2023-45857 Bump axios to non-vulnurable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.3.4",
+        "axios": "^1.6.2",
         "json-stringify-safe": "5.0.x",
         "moment": "2.29.4"
       },
@@ -1340,9 +1340,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/axios": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -5281,9 +5281,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "axios": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "loggly"
   ],
   "dependencies": {
-    "axios": "1.3.4",
-    "moment": "2.29.4",
-    "json-stringify-safe": "5.0.x"
+    "axios": "^1.6.2",
+    "json-stringify-safe": "5.0.x",
+    "moment": "2.29.4"
   },
   "devDependencies": {
     "eslint": "^8.2.0",


### PR DESCRIPTION
I bumped axios up to the latest version. I left in the ^ to allow for future necessary updates, but I'm happy to remove that if you prefer!

`npm install` also sorted dependencies alphabetically. 