### PR TITLE
Code cleaning & avoid stack overflow for recursive serialization

### DIFF
--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -427,17 +427,3 @@ common.serialize = function (obj, key) {
 
   return msg;
 };
-
-//
-// function clone (obj)
-//   Helper method for deep cloning pure JSON objects
-//   i.e. JSON objects that are either literals or objects (no Arrays, etc)
-//
-common.clone = function (obj) {
-  var clone = {};
-  for (var i in obj) {
-    clone[i] = obj[i] instanceof Object ? common.clone(obj[i]) : obj[i];
-  }
-
-  return clone;
-};

--- a/lib/loggly/common.js
+++ b/lib/loggly/common.js
@@ -12,7 +12,8 @@
 var arrSize = 100,
     arrMsg = [],
     timerFunction = null,
-    sendBulkInMs = 5000;
+    sendBulkInMs = 5000,
+    maxSerializeDepth = 10;
 
 // 
 // Variables for buffer array
@@ -384,7 +385,7 @@ common.loggly = function () {
 // Performs simple comma-separated, `key=value` serialization for Loggly when
 // logging for non-JSON values.
 //
-common.serialize = function (obj, key) {
+common.serialize = function (obj, key, depth) {
   if (obj === null) {
     obj = 'null';
   }
@@ -395,6 +396,13 @@ common.serialize = function (obj, key) {
     obj = 'false';
   }
 
+  if (typeof depth === 'number') {
+    depth++;
+  }
+  else {
+    depth = 1;
+  }
+
   if (typeof obj !== 'object') {
     return key ? key + '=' + obj : obj;
   }
@@ -403,22 +411,24 @@ common.serialize = function (obj, key) {
       keys = Object.keys(obj),
       length = keys.length;
 
-  for (var i = 0; i < length; i++) {
-    if (Array.isArray(obj[keys[i]])) {
-      msg += keys[i] + '=[';
-
-      for (var j = 0, l = obj[keys[i]].length; j < l; j++) {
-        msg += common.serialize(obj[keys[i]][j]);
-        if (j < l - 1) {
-          msg += ', ';
+  if (depth < maxSerializeDepth) {
+    for (var i = 0; i < length; i++) {
+      if (Array.isArray(obj[keys[i]])) {
+        msg += keys[i] + '=[';
+  
+        for (var j = 0, l = obj[keys[i]].length; j < l; j++) {
+          msg += common.serialize(obj[keys[i]][j], depth);
+          if (j < l - 1) {
+            msg += ', ';
+          }
         }
+  
+        msg += ']';
       }
-
-      msg += ']';
-    }
-    else {
-      msg += common.serialize(obj[keys[i]], keys[i]);
-    }
+      else {
+        msg += common.serialize(obj[keys[i]], keys[i], depth);
+      }
+  }
 
     if (i < length - 1) {
       msg += ', ';


### PR DESCRIPTION
1/ The clone function is not used anywhere in the dependency - we deleted it

2/ Serialization is throwing a stack overflow exception for recursive objects:
```
RangeError: Maximum call stack size exceeded
    at Function.valueOf (<anonymous>)
    at Object.common.serialize (/<app>/node_modules/node-loggly-bulk/lib/loggly/common.js:399:28)
    at Object.common.serialize (/<app>/node_modules/node-loggly-bulk/lib/loggly/common.js:420:21)
    at Object.common.serialize (/<app>/node_modules/node-loggly-bulk/lib/loggly/common.js:420:21)
    at Object.common.serialize (/<app>/node_modules/node-loggly-bulk/lib/loggly/common.js:420:21)
    at Object.common.serialize (/<app>/node_modules/node-loggly-bulk/lib/loggly/common.js:420:21)
    at Object.common.serialize (/<app>/node_modules/node-loggly-bulk/lib/loggly/common.js:420:21)
    at Object.common.serialize (/<app>/node_modules/node-loggly-bulk/lib/loggly/common.js:420:21)
    at Object.common.serialize (/<app>/node_modules/node-loggly-bulk/lib/loggly/common.js:420:21)
    at Object.common.serialize (/<app>/node_modules/node-loggly-bulk/lib/loggly/common.js:420:21)
```
We added a max depth for avoiding it

---

Tests are passing

```
 PASS  test/logs.test.js
  when trying to send logs
    ✓ should set correct token, URL, tags, headers and response (4 ms)
    ✓ should work with a non-json message
    ✓ should work with a json message
    ✓ should retry several times when error occurs (11 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        0.797 s
Ran all test suites.
```